### PR TITLE
Ktg bondhome

### DIFF
--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceProperties.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondDeviceProperties.java
@@ -45,7 +45,7 @@ public class BondDeviceProperties {
     public boolean trustState;
     // The device address
     @Expose(serialize = true, deserialize = true)
-    public long addr;
+    public String addr = "";
     // The fan radio frequency
     @Expose(serialize = true, deserialize = true)
     public int freq;

--- a/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
+++ b/bundles/org.openhab.binding.bondhome/src/main/java/org/openhab/binding/bondhome/internal/api/BondHttpApi.java
@@ -84,8 +84,9 @@ public class BondHttpApi {
         JsonObject obj = element.getAsJsonObject();
         Set<Map.Entry<String, JsonElement>> entries = obj.entrySet();
         for (Map.Entry<String, JsonElement> entry : entries) {
-            if (!entry.getKey().equals("_")) {
-                list.add(entry.getKey());
+            String key = entry.getKey();
+            if (!key.startsWith("_")) {
+                list.add(key);
             }
         }
         return list;


### PR DESCRIPTION
[bondhome] fix issues related to firmware v3

This fixes two issues in the bondhome addon related to firmware v3:
1. addr should be handled as a String not a long
2. a new magic non-device in the device enumeration that breaks the binding.